### PR TITLE
One potential solution

### DIFF
--- a/java/src/main/java/com/datafiniti/importer/Main.java
+++ b/java/src/main/java/com/datafiniti/importer/Main.java
@@ -4,6 +4,6 @@ import java.io.IOException;
 
 class Main {
     public static void main(String[] args) throws IOException {
-        Baseline.run();
+        Solution.run();
     }
 }

--- a/java/src/main/java/com/datafiniti/importer/Solution.java
+++ b/java/src/main/java/com/datafiniti/importer/Solution.java
@@ -1,0 +1,69 @@
+package com.datafiniti.importer;
+
+import redis.clients.jedis.Jedis;
+import java.io.IOException;
+
+class Solution {
+    public static void run() throws IOException {
+        ESClient.connect();
+        ESClient.setup();
+
+        seedRedis(10_000);
+
+        int threadCount = 0;
+        int threadCapacity = 7;
+
+        do {
+            Thread worker = createWorkerThread();
+            worker.start();
+            System.out.println("=> Just spun up a new worker thread");
+            threadCount++;
+        } while (threadCount != threadCapacity);
+
+    }
+
+    /**
+     * Creates a new thread to begin processessing Elastisearch inserts concurrently
+     */
+    public static Thread createWorkerThread() {
+        return new Thread(() -> {
+            try {
+				importRecords();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+        });
+    }
+
+
+    public static void importRecords() throws IOException {
+        Jedis jedis = new Jedis("redis");
+
+        System.out.println("importing records from redis -> elasticsearch");
+
+        String record;
+        while ((record = jedis.rpop("records")) != null) {
+            ESClient.insert(record);
+        }
+
+        System.out.println("done importing.");
+    }
+
+    public static void seedRedis(Integer numRecords) throws IOException {
+        Jedis jedis = new Jedis("redis");
+
+        System.out.println("flushing redis");
+        jedis.flushAll();
+
+        System.out.println("seeding redis with " + numRecords + " records.");
+        for (int i = 0; i < numRecords; i += 1) {
+            jedis.rpush("records", Utils.createRecord());
+
+            if (i % (numRecords / 10) == 0) {
+                System.out.println(i + " records seeded.");
+            }
+        }
+
+        jedis.close();
+    }
+}


### PR DESCRIPTION
Hi Moe,

Not sure if this was the solution you're looking for, but I managed to get Indexing above 100 records/ second after increasing the thread count. 

My computer seemed to max out around 7 threads, but per 'Tune for Indexing' on Elastisearch's page' (https://www.elastic.co/guide/en/elasticsearch/reference/master/tune-for-indexing-speed.html) - "Similarly to sizing bulk requests, only testing can tell what the optimal number of workers is". 

Wasn't able to fully get Bulk Requests working without getting an Error in Java as that was my second route to start researching. Let me know what you think.

All the best,

David Poulos